### PR TITLE
Only install cryptominisat5

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,6 +20,3 @@ cmake \
   ..
 
 make -j${CPU_COUNT} install
-
-ln -s "$PREFIX/bin/cryptominisat5_simple" "$PREFIX/bin/cryptominisat_simple"
-ln -s "$PREFIX/bin/cryptominisat5" "$PREFIX/bin/cryptominisat"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - 0002-shared-breaks-build-on-OSX.patch
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
 
 requirements:
@@ -35,12 +35,10 @@ requirements:
 
 test:
   commands:
-    - conda inspect linkages -p $PREFIX cryptominisat  # [not win]
-    - conda inspect objects -p $PREFIX cryptominisat  # [osx]
-    - echo -e '1 0\n-1 0' | cryptominisat | grep UNSATISFIABLE
-    - echo -e '1 0\n1 -1 0' | cryptominisat | grep SATISFIABLE
-    - echo -e '1 0\n-1 0' | cryptominisat_simple | grep UNSATISFIABLE
-    - echo -e '1 0\n1 -1 0' | cryptominisat_simple | grep SATISFIABLE
+    - conda inspect linkages -p $PREFIX cryptominisat5  # [not win]
+    - conda inspect objects -p $PREFIX cryptominisat5  # [osx]
+    - echo -e '1 0\n-1 0' | cryptominisat5 | grep UNSATISFIABLE
+    - echo -e '1 0\n1 -1 0' | cryptominisat5 | grep SATISFIABLE
 
 about:
   home: https://github.com/msoos/cryptominisat

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,8 +35,8 @@ requirements:
 
 test:
   commands:
-    - conda inspect linkages -p $PREFIX cryptominisat5  # [not win]
-    - conda inspect objects -p $PREFIX cryptominisat5  # [osx]
+    - conda inspect linkages -p $PREFIX cryptominisat  # [not win]
+    - conda inspect objects -p $PREFIX cryptominisat  # [osx]
     - echo -e '1 0\n-1 0' | cryptominisat5 | grep UNSATISFIABLE
     - echo -e '1 0\n1 -1 0' | cryptominisat5 | grep SATISFIABLE
 


### PR DESCRIPTION
see https://github.com/msoos/cryptominisat/issues/468
* Do not install cryptominisat5_simple. There is no reason to use it if
  cryptominisat5 is available.
* Install cryptominisat5 without renaming it. It's intended to be called that
  by upstream.